### PR TITLE
✨ issue #19 問題文表示用の上部画面作成

### DIFF
--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -34,30 +34,54 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
 
     return FutureBuilder(
       future: (!isFirstLoad && popQuestion.imagePath != '')
+          // if-else文の別の書き方
           ? preImageLoad(popQuestion.imagePath)
           : null,
       builder: (context, snapshot) {
+        // stream接続の現在の状態を確認しているif文
+        // stream待機状態の場合、CircularProgressIndicator()を表示させている
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(
             child: CircularProgressIndicator(),
           );
         }
-
         return Stack(
           children: [
             Column(
               children: [
-                Text(popQuestion.text),
-                if (popQuestion.imagePath != '')
-                  Image.asset(
-                    popQuestion.imagePath,
-                    width: MediaQuery.of(context).size.width * 0.95,
-                    fit: BoxFit.fitWidth,
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        // imagePathがでない場合、'問題文と画像'を表示する実装
+                        Visibility(
+                          visible: popQuestion.imagePath != '',
+                          child: Column(
+                            children: [
+                              Text(popQuestion.text),
+                              Image.asset(
+                                popQuestion.imagePath,
+                                width: MediaQuery.of(context).size.width * 0.95,
+                                fit: BoxFit.fitWidth,
+                              ),
+                            ],
+                          ),
+                        ),
+                        // imagePathが空の場合、'問題文のみ'を表示する実装
+                        Visibility(
+                          visible: popQuestion.imagePath == '',
+                          child: Text(popQuestion.text),
+                        ),
+                      ],
+                    ),
                   ),
+                ),
+                // 選択肢と'次へ'ボタン表示部分
                 const QuizChoices(),
                 const GoNextButton()
               ],
             ),
+            // '正解'、'不正解'表示部分
             const AnswerResult()
           ],
         );
@@ -69,7 +93,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
     if (imagePath != '') {
       await precacheImage(AssetImage(imagePath), context);
     }
-
+    // widgetが画面に表示されている場合の処理
     if (mounted) {
       setState(() {
         isFirstLoad = true;

--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -50,7 +50,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
             children: <Widget>[
               Expanded(
                 flex: 1,
-                child: Column(
+                child: ListView(
                   children: [
                     Text(popQuestion.text),
                     if(popQuestion.imagePath != '')

--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -50,29 +50,17 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
             children: <Widget>[
               Expanded(
                 flex: 1,
-                child: ListView(
+                child: Column(
                   children: [
-                    // imagePathがでない場合、'問題文と画像'を表示する実装
-                    Visibility(
-                      visible: popQuestion.imagePath != '',
-                      child: Column(
-                        children: [
-                          Text(popQuestion.text),
-                          Image.asset(
-                            popQuestion.imagePath,
-                            width: MediaQuery.of(context).size.width * 0.95,
-                            fit: BoxFit.fitWidth,
-                          ),
-                        ],
+                    Text(popQuestion.text),
+                    if(popQuestion.imagePath != '')
+                      Image.asset(
+                        popQuestion.imagePath,
+                        width: MediaQuery.of(context).size.width * 0.95,
+                        fit: BoxFit.fitWidth,
                       ),
-                    ),
-                    // imagePathが空の場合、'問題文のみ'を表示する実装
-                    Visibility(
-                      visible: popQuestion.imagePath == '',
-                      child: Text(popQuestion.text),
-                    ),
                   ],
-                ),
+                )
               ),
               Expanded(
                 flex: 1,

--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -45,47 +45,48 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
             child: CircularProgressIndicator(),
           );
         }
-        return Stack(
-          children: [
-            Column(
-              children: [
-                Positioned(
-                  top: MediaQuery.of(context).size.height * 0.25,
-                  left: MediaQuery.of(context).size.width / 2 - 50,
-                  child: SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        // imagePathがでない場合、'問題文と画像'を表示する実装
-                        Visibility(
-                          visible: popQuestion.imagePath != '',
-                          child: Column(
-                            children: [
-                              Text(popQuestion.text),
-                              Image.asset(
-                                popQuestion.imagePath,
-                                width: MediaQuery.of(context).size.width * 0.95,
-                                fit: BoxFit.fitWidth,
-                              ),
-                            ],
+        return Scaffold(
+          body: Column(
+            children: <Widget>[
+              Expanded(
+                flex: 1,
+                child: ListView(
+                  children: [
+                    // imagePathがでない場合、'問題文と画像'を表示する実装
+                    Visibility(
+                      visible: popQuestion.imagePath != '',
+                      child: Column(
+                        children: [
+                          Text(popQuestion.text),
+                          Image.asset(
+                            popQuestion.imagePath,
+                            width: MediaQuery.of(context).size.width * 0.95,
+                            fit: BoxFit.fitWidth,
                           ),
-                        ),
-                        // imagePathが空の場合、'問題文のみ'を表示する実装
-                        Visibility(
-                          visible: popQuestion.imagePath == '',
-                          child: Text(popQuestion.text),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
-                  ),
+                    // imagePathが空の場合、'問題文のみ'を表示する実装
+                    Visibility(
+                      visible: popQuestion.imagePath == '',
+                      child: Text(popQuestion.text),
+                    ),
+                  ],
                 ),
-                // 選択肢と'次へ'ボタン表示部分
-                const QuizChoices(),
-                const GoNextButton()
-              ],
-            ),
-            // '正解'、'不正解'表示部分
-            const AnswerResult()
-          ],
+              ),
+              Expanded(
+                flex: 1,
+                child: Column(
+                  // ignore: prefer_const_literals_to_create_immutables
+                  children: [
+                    const QuizChoices(),
+                    const GoNextButton(),
+                    const AnswerResult()
+                  ],
+                ),
+              )
+            ],
+          ),
         );
       },
     );

--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -49,7 +49,9 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
           children: [
             Column(
               children: [
-                Expanded(
+                Positioned(
+                  top: MediaQuery.of(context).size.height * 0.25,
+                  left: MediaQuery.of(context).size.width / 2 - 50,
                   child: SingleChildScrollView(
                     child: Column(
                       children: [

--- a/lib/View/try_questions/questions_area.dart
+++ b/lib/View/try_questions/questions_area.dart
@@ -60,7 +60,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
                         fit: BoxFit.fitWidth,
                       ),
                   ],
-                )
+                ),
               ),
               Expanded(
                 flex: 1,


### PR DESCRIPTION
#19 より転記

> @TakeRai 
> 
> > 問題文の長さによって動的にスクロール表示されるWidgetを実装したい
> > 
> > ただし、画面下部には解答選択肢を表示する予定なので、スクロールWidgetは画面上半分のみの実装をお願いしたいです
> 
> こちら、実装完了致しました。
> 
> **画面スクロール実装エビデンス動画▼**
> https://user-images.githubusercontent.com/111550856/212527277-3b425632-7dc7-4f9e-b96a-32267ebdf156.mov
> 
> 
> **実装結果▼**
> ![issue#19_widget構成](https://user-images.githubusercontent.com/111550856/212527313-5078f486-df0b-4baf-ba1d-d134289e8fb3.png)
> 
> **検証環境▼**
> Pixel 6 API33
> Android Tiramisu Google APIs | arm64
> 
> **備考▼**
> 画面上下の２分割のwidget構成に伴い、`正解・不正解表示`を`画面下部のExpanded`に取り込み、選択肢下の表示に変更となっております。
> ![issue#19_正誤表示変更後](https://user-images.githubusercontent.com/111550856/212527566-e0075b4b-f99e-4ea6-a694-1b0aced3023a.png)






