### PR TITLE
issue #29 ✨ 問題画面の実装・修正

### DIFF
--- a/lib/View/try_questions/parts/go_next_button.dart
+++ b/lib/View/try_questions/parts/go_next_button.dart
@@ -18,18 +18,27 @@ class GoNextButton extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    return ElevatedButton(
-      onPressed: () async {
-        questionP.quizAnswerChange('');
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      width: 500,
+      child: ElevatedButton(
+        // 試験的に'次へ'ボタンを丸くしてみた ------->
+        style: ElevatedButton.styleFrom(
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(50))),
+        // ------------------------------------->
+        onPressed: () async {
+          questionP.quizAnswerChange('');
 
-        if (unsolvedQuestions.isNotEmpty) {
-          List<Map<String, dynamic>> state = await StudyStateModel.getState();
-          baseP.goNextQ(stateId: state[0]['id']);
-        } else {
-          baseP.goEnd();
-        }
-      },
-      child: const Text('次へ'),
+          if (unsolvedQuestions.isNotEmpty) {
+            List<Map<String, dynamic>> state = await StudyStateModel.getState();
+            baseP.goNextQ(stateId: state[0]['id']);
+          } else {
+            baseP.goEnd();
+          }
+        },
+        child: const Text('次へ'),
+      ),
     );
   }
 }

--- a/lib/View/try_questions/parts/quiz_choices.dart
+++ b/lib/View/try_questions/parts/quiz_choices.dart
@@ -37,25 +37,42 @@ class QuizChoicesState extends ConsumerState<QuizChoices> {
     return Column(
       children: [
         for (var i = 0; i < 4; i++) ...[
-          ElevatedButton(
-            onPressed: quizAnswer == ''
-                ? () {
-                    questionP.quizAnswerChange(
-                      i == popQuestion.answer ? '正解' : '不正解',
-                    );
+          Container(
+            // 横幅指定　左右に16px、上下に0.5pxの隙間を開ける
+            margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 0.5),
+            width: 500,
+            // 選択肢ボタンを横の揃える
+            alignment: Alignment.centerLeft,
+            child: ElevatedButton(
+              onPressed: quizAnswer == ''
+                  ? () {
+                      // 回答選択肢が問題の正解だった場合'正解'、そうでない場合'不正解'を返す三項演算子
+                      questionP.quizAnswerChange(
+                        i == popQuestion.answer ? '正解' : '不正解',
+                      );
 
-                    specificRecord.isNotEmpty
-                        ? UserRecordsModel.updateRecord(
-                            popQuestionStr,
-                            i == popQuestion.answer ? 0 : 1,
-                          )
-                        : UserRecordsModel.createRecord(
-                            popQuestionStr: popQuestionStr,
-                            isCorrect: i == popQuestion.answer ? 0 : 1,
-                          );
-                  }
-                : null,
-            child: Text(popQuestion.choices[i]),
+                      // 成績の有無によってDBに成績を作成するか、既存の成績を更新するかの三項演算子
+                      specificRecord.isNotEmpty
+                          ? UserRecordsModel.updateRecord(
+                              popQuestionStr,
+                              i == popQuestion.answer ? 0 : 1,
+                            )
+                          : UserRecordsModel.createRecord(
+                              popQuestionStr: popQuestionStr,
+                              isCorrect: i == popQuestion.answer ? 0 : 1,
+                            );
+                    }
+                  // quizAnswerが空ではなかった場合の処理は無い
+                  // ここもう少しスマートに書けたりしないかな？
+                  : null,
+              child: Container(
+                // ボタンの文字を左寄りに
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  popQuestion.choices[i],
+                ),
+              ),
+            ),
           )
         ],
       ],


### PR DESCRIPTION
## 🎫 課題へのリンク

- issue #29 
- [Jira LU11-35](https://pastquiz11.atlassian.net/browse/LU11-35)

## ✨ やったこと

- 問題表示画面、問題選択肢部分のデザイン整理
  - 問題選択肢
  - 「次へ」ボタン

## 🚩 やらないこと

- 「正解/不正解」表示のデザイン整理
- 画面全体のテーマ設定、カラーリング
- 選択肢へ「ア・イ・ウ・エ」の表示
  - ユーザーの操作性にあまり寄与しなさそうなことと、回答ロジックに直接関わりが無く、必要性が薄く感じられたため

## 👍 できるようになること（ユーザ目線）

- ボタンの横幅が統一されるので画面に一体感が出る
- （試験的導入）「次へ」ボタンのデザインを選択肢ボタンより少しだけ変化をつけることで視認性が上がる？
- ボタンサイズが大きくなったので選択肢の押下がしやすくなった

## 👎 できなくなること（ユーザ目線）

- なし

## ✅ 動作確認

検証環境：Androidエミュレータ（Pixel 6 Pro API 33 Android Tiramisu Google APIs | arm64）

|選択肢（短）|選択肢（長）|回答後 |
|-------|-------|-------|
| ![スクリーンショット 2023-01-18 11 56 07](https://user-images.githubusercontent.com/111550856/213074329-c894e8b1-4934-46f1-b936-297e0f3384ed.png)|![スクリーンショット 2023-01-18 11 56 41](https://user-images.githubusercontent.com/111550856/213074368-6bf4da38-bd39-4614-90a3-9928d750124e.png)|![スクリーンショット 2023-01-18 11 56 30](https://user-images.githubusercontent.com/111550856/213074389-5c1a460e-8100-43bc-8ce3-021821db05d3.png)|

## 🔀 マージ条件

- [x] @TakeRai のレビューに通過すること

## 👀 その他

- 「次へ」ボタンの丸いデザイン実装はコメントアウトでわかりやすくマーキングしてあります。削除の際はマーキング部分を丸ごと削除してください。他の部分との依存関係はありません。

