### PR TITLE
Feature/kaitou gamen mano

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,9 +14,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       /// false にすることで画面右上の debug 文字を消すことができる
       debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.orange,
+      ),
       home: DrawerRouter(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.orange,
       ),
-      home: DrawerRouter(),
+      home: const DrawerRouter(),
     );
   }
 }

--- a/lib/view/try_questions/parts/quiz_answer_result.dart
+++ b/lib/view/try_questions/parts/quiz_answer_result.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../try_questions.dart';
 
-class AnswerResult extends ConsumerWidget {
-  const AnswerResult({super.key});
+class QuizAnswerResult extends ConsumerWidget {
+  const QuizAnswerResult({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/view/try_questions/parts/quiz_choices.dart
+++ b/lib/view/try_questions/parts/quiz_choices.dart
@@ -37,10 +37,10 @@ class QuizChoicesState extends ConsumerState<QuizChoices> {
       children: [
         for (var i = 0; i < 4; i++) ...[
           Container(
-            // 横幅指定　左右に16px、上下に0.5pxの隙間を開ける
+            // 横幅指定 左右に16px、上下に0.5pxの隙間を開ける
             margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 0.5),
             width: 500,
-            // 選択肢ボタンを横の揃える
+            // 選択肢ボタンを左寄りに揃える
             alignment: Alignment.centerLeft,
             child: ElevatedButton(
               onPressed: quizAnswer == ''

--- a/lib/view/try_questions/parts/quiz_choices.dart
+++ b/lib/view/try_questions/parts/quiz_choices.dart
@@ -33,46 +33,83 @@ class QuizChoicesState extends ConsumerState<QuizChoices> {
 
     getRecordHere(popQuestionStr);
 
+    const textAiueo = ['ア', 'イ', 'ウ', 'エ', 'オ'];
+    const sizeAiueo = 30.0;
+    const colorAiueoBackground = Colors.white;
+    const colorChoice = Colors.orange;
+    const radiusRect = 15.0;
+    const paddingChoiseString =
+        EdgeInsets.only(left: 15, top: 2, bottom: 2, right: 2);
+
     return Column(
       children: [
         for (var i = 0; i < 4; i++) ...[
-          Container(
-            // 横幅指定 左右に16px、上下に0.5pxの隙間を開ける
-            margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 0.5),
-            width: 500,
-            // 選択肢ボタンを左寄りに揃える
-            alignment: Alignment.centerLeft,
-            child: ElevatedButton(
-              onPressed: quizAnswer == ''
-                  ? () {
-                      // 回答選択肢が問題の正解だった場合'正解'、そうでない場合'不正解'を返す三項演算子
-                      questionP.quizAnswerChange(
-                        i == popQuestion.answer ? '正解' : '不正解',
-                      );
-
-                      // 成績の有無によってDBに成績を作成するか、既存の成績を更新するかの三項演算子
-                      specificRecord.isNotEmpty
-                          ? UserRecordsModel.updateRecord(
-                              popQuestionStr,
-                              i == popQuestion.answer ? 0 : 1,
-                            )
-                          : UserRecordsModel.createRecord(
-                              popQuestionStr: popQuestionStr,
-                              isCorrect: i == popQuestion.answer ? 0 : 1,
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // アイウエ部
+                Container(
+                  width: 50,
+                  alignment: Alignment.centerLeft,
+                  decoration: const BoxDecoration(
+                    color: colorChoice,
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(radiusRect),
+                      bottomLeft: Radius.circular(radiusRect),
+                    ),
+                  ),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      shape: const CircleBorder(),
+                      backgroundColor: colorAiueoBackground,
+                      minimumSize: const Size(sizeAiueo, sizeAiueo),
+                    ),
+                    onPressed: quizAnswer == ''
+                        ? () {
+                            // 回答選択肢が問題の正解だった場合'正解'、そうでない場合'不正解'を返す三項演算子
+                            questionP.quizAnswerChange(
+                              i == popQuestion.answer ? '正解' : '不正解',
                             );
-                    }
-                  // quizAnswerが空ではなかった場合の処理は無い
-                  // ここもう少しスマートに書けたりしないかな？
-                  : null,
-              child: Container(
-                // ボタンの文字を左寄りに
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  popQuestion.choices[i],
+                            // 成績の有無によってDBに成績を作成するか、既存の成績を更新するかの三項演算子
+                            specificRecord.isNotEmpty
+                                ? UserRecordsModel.updateRecord(
+                                    popQuestionStr,
+                                    i == popQuestion.answer ? 0 : 1,
+                                  )
+                                : UserRecordsModel.createRecord(
+                                    popQuestionStr: popQuestionStr,
+                                    isCorrect: i == popQuestion.answer ? 0 : 1,
+                                  );
+                          }
+                        // quizAnswerが空ではなかった場合の処理は無い
+                        // ここもう少しスマートに書けたりしないかな？
+                        : null,
+                    child: Text(textAiueo[i]),
+                  ),
                 ),
-              ),
+                // 選択肢文章部
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    padding: paddingChoiseString,
+                    alignment: Alignment.centerLeft,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: colorChoice),
+                      borderRadius: const BorderRadius.only(
+                        topRight: Radius.circular(radiusRect),
+                        bottomRight: Radius.circular(radiusRect),
+                      ),
+                    ),
+                    child: Text(
+                      popQuestion.choices[i],
+                    ),
+                  ),
+                ),
+              ],
             ),
-          )
+          ),
+          const SizedBox(height: 10),
         ],
       ],
     );

--- a/lib/view/try_questions/parts/quiz_devider.dart
+++ b/lib/view/try_questions/parts/quiz_devider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class QuizDevider extends StatelessWidget {
+  const QuizDevider({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: Color(0xFF333333),
+            width: 1,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/try_questions/parts/quiz_divider.dart
+++ b/lib/view/try_questions/parts/quiz_divider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class QuizDevider extends StatelessWidget {
-  const QuizDevider({
+class QuizDivider extends StatelessWidget {
+  const QuizDivider({
     Key? key,
   }) : super(key: key);
 

--- a/lib/view/try_questions/parts/quiz_go_next_button.dart
+++ b/lib/view/try_questions/parts/quiz_go_next_button.dart
@@ -5,8 +5,8 @@ import '../../../model/base_model.dart';
 import '../../../service/database/study_state_db.dart';
 import '../try_questions.dart';
 
-class GoNextButton extends ConsumerWidget {
-  const GoNextButton({super.key});
+class QuizGoNextButton extends ConsumerWidget {
+  const QuizGoNextButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/view/try_questions/parts/quiz_question.dart
+++ b/lib/view/try_questions/parts/quiz_question.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../../questions/question.dart';
+
+class QuizQuestion extends StatelessWidget {
+  const QuizQuestion({
+    Key? key,
+    required this.popQuestion,
+  }) : super(key: key);
+
+  final Question popQuestion;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        // 問題 本文
+        Text(popQuestion.text),
+        const SizedBox(height: 8.0),
+        // 問題 付図
+        if (popQuestion.imagePath != '')
+          Column(
+            children: [
+              Image.asset(
+                popQuestion.imagePath,
+                width: MediaQuery.of(context).size.width * 0.95,
+                fit: BoxFit.fitWidth,
+              ),
+              const SizedBox(height: 8.0),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/view/try_questions/parts/quiz_question_info.dart
+++ b/lib/view/try_questions/parts/quiz_question_info.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class QuizQuestionInfo extends StatelessWidget {
+  const QuizQuestionInfo({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+                margin: const EdgeInsets.all(1.0),
+                child: const Text('演習回数:88回目')),
+            Container(
+                margin: const EdgeInsets.all(1.0),
+                child: const Text('全体正解率:100%')),
+          ],
+        ),
+        const Spacer(),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Container(
+              margin: const EdgeInsets.all(1.0),
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1.0),
+              decoration: BoxDecoration(
+                color: Colors.pink[300],
+                borderRadius: BorderRadius.circular(15),
+              ),
+              child: const Text('アルゴリズムとプログラミング'),
+            ),
+            const SizedBox(
+              height: 1,
+            ),
+            Container(
+              margin: const EdgeInsets.all(1.0),
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1.0),
+              decoration: BoxDecoration(
+                color: Colors.purple[300],
+                borderRadius: BorderRadius.circular(15),
+              ),
+              child: const Text('テクノロジー'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -65,7 +65,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
                     child: QuizQuestionInfo(),
                   ),
                   const SizedBox(height: marginAreaBottom),
-                  const QuizDevider(),
+                  const QuizDivider(),
                   const SizedBox(height: marginAreaBottom),
                   Expanded(
                     flex: 1,
@@ -75,7 +75,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
                     ),
                   ),
                   const SizedBox(height: marginAreaBottom),
-                  const QuizDevider(),
+                  const QuizDivider(),
                   const SizedBox(height: marginAreaBottom),
                   Expanded(
                     flex: 1,

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -5,7 +5,7 @@ import 'package:past_questions/view/try_questions/try_questions.dart';
 import '../../questions/question.dart';
 import 'parts/quiz_answer_result.dart';
 import 'parts/quiz_choices.dart';
-import 'parts/quiz_devider.dart';
+import 'parts/quiz_divider.dart';
 import 'parts/quiz_go_next_button.dart';
 import 'parts/quiz_question_info.dart';
 import 'parts/quiz_question.dart';

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -28,8 +28,15 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
     final popIndex = int.parse(popQuestionStr.substring(4));
     final popQuestion = yearMap[popYear]![popIndex];
 
-    double screenWidth = MediaQuery.of(context).size.width;
-    double screenHeight = MediaQuery.of(context).size.height;
+    const paddingScreen = 16.0;
+    const marginAreaBottom = 8.0;
+
+    // for Debug
+    const isDebug = false;
+    // ignore: dead_code
+    const colorArea = isDebug ? Colors.white : Colors.transparent;
+    // ignore: dead_code
+    final colorBackground = isDebug ? Colors.amber[100] : Colors.white;
 
     return FutureBuilder(
       future: (!isFirstLoad && popQuestion.imagePath != '')
@@ -45,58 +52,131 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
           );
         }
         return Scaffold(
-          body: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Column(
-              children: <Widget>[
-                // 問題 領域 (最大:画面上部50%)
-                ConstrainedBox(
-                  constraints:
-                      BoxConstraints.loose(Size(screenWidth, screenHeight / 2)),
-                  child: ListView(
-                    children: [
-                      // 問題 本文
-                      Text(popQuestion.text),
-                      const SizedBox(height: 8.0),
-                      // 問題 付図
-                      if (popQuestion.imagePath != '')
+          body: Container(
+            color: colorBackground,
+            child: Padding(
+              padding: const EdgeInsets.all(paddingScreen),
+              child: Column(
+                children: <Widget>[
+                  // 問題情報 領域
+                  Container(
+                    color: colorArea,
+                    child: Row(
+                      children: [
                         Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Image.asset(
-                              popQuestion.imagePath,
-                              width: MediaQuery.of(context).size.width * 0.95,
-                              fit: BoxFit.fitWidth,
-                            ),
-                            const SizedBox(height: 8.0),
+                            Container(
+                                margin: const EdgeInsets.all(1.0),
+                                child: const Text('この問題何回目: ...')),
+                            Container(
+                                margin: const EdgeInsets.all(1.0),
+                                child: const Text('全体正解率:100%')),
                           ],
                         ),
-                      // 区切り線
-                      Container(
-                        decoration: const BoxDecoration(
-                          border: Border(
-                            bottom: BorderSide(
-                              color: Colors.black,
-                              width: 1,
+                        const Spacer(),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Container(
+                              margin: const EdgeInsets.all(1.0),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 5, vertical: 1.0),
+                              decoration: BoxDecoration(
+                                color: Colors.pink[300],
+                                borderRadius: BorderRadius.circular(15),
+                              ),
+                              child: const Text('アルゴリズムとプログラミング'),
                             ),
-                          ),
+                            const SizedBox(
+                              height: 1,
+                            ),
+                            Container(
+                              margin: const EdgeInsets.all(1.0),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 5, vertical: 1.0),
+                              decoration: BoxDecoration(
+                                color: Colors.purple[300],
+                                borderRadius: BorderRadius.circular(15),
+                              ),
+                              child: const Text('テクノロジー'),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: marginAreaBottom),
+                  // 区切り線
+                  Container(
+                    decoration: const BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: Color(0xFF333333),
+                          width: 1,
                         ),
                       ),
-                    ],
+                    ),
                   ),
-                ),
-                // 回答 領域
-                Expanded(
-                  flex: 1,
-                  child: Column(
-                    // ignore: prefer_const_literals_to_create_immutables
-                    children: [
-                      const QuizChoices(),
-                      const GoNextButton(),
-                      const AnswerResult(),
-                    ],
+                  const SizedBox(height: marginAreaBottom),
+                  // 問題 領域 (最大:画面上部50%)
+                  Expanded(
+                    flex: 1,
+                    child: Container(
+                      color: colorArea,
+                      child: ListView(
+                        children: [
+                          // 問題 本文
+                          Text(popQuestion.text),
+                          const SizedBox(height: 8.0),
+                          // 問題 付図
+                          if (popQuestion.imagePath != '')
+                            Column(
+                              children: [
+                                Image.asset(
+                                  popQuestion.imagePath,
+                                  width:
+                                      MediaQuery.of(context).size.width * 0.95,
+                                  fit: BoxFit.fitWidth,
+                                ),
+                                const SizedBox(height: 8.0),
+                              ],
+                            ),
+                          // 区切り線
+                        ],
+                      ),
+                    ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: marginAreaBottom),
+                  // 区切り線
+                  Container(
+                    decoration: const BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: Color(0xFF333333),
+                          width: 1,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: marginAreaBottom),
+                  // 回答 領域
+                  Expanded(
+                    flex: 1,
+                    child: Container(
+                      color: colorArea,
+                      child: Column(
+                        // ignore: prefer_const_literals_to_create_immutables
+                        children: [
+                          const QuizChoices(),
+                          const GoNextButton(),
+                          const AnswerResult(),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         );

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -28,6 +28,9 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
     final popIndex = int.parse(popQuestionStr.substring(4));
     final popQuestion = yearMap[popYear]![popIndex];
 
+    double screenWidth = MediaQuery.of(context).size.width;
+    double screenHeight = MediaQuery.of(context).size.height;
+
     return FutureBuilder(
       future: (!isFirstLoad && popQuestion.imagePath != '')
           // if-else文の別の書き方
@@ -42,34 +45,59 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
           );
         }
         return Scaffold(
-          body: Column(
-            children: <Widget>[
-              Expanded(
-                flex: 1,
-                child: ListView(
-                  children: [
-                    Text(popQuestion.text),
-                    if (popQuestion.imagePath != '')
-                      Image.asset(
-                        popQuestion.imagePath,
-                        width: MediaQuery.of(context).size.width * 0.95,
-                        fit: BoxFit.fitWidth,
+          body: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: <Widget>[
+                // 問題 領域 (最大:画面上部50%)
+                ConstrainedBox(
+                  constraints:
+                      BoxConstraints.loose(Size(screenWidth, screenHeight / 2)),
+                  child: ListView(
+                    children: [
+                      // 問題 本文
+                      Text(popQuestion.text),
+                      const SizedBox(height: 8.0),
+                      // 問題 付図
+                      if (popQuestion.imagePath != '')
+                        Column(
+                          children: [
+                            Image.asset(
+                              popQuestion.imagePath,
+                              width: MediaQuery.of(context).size.width * 0.95,
+                              fit: BoxFit.fitWidth,
+                            ),
+                            const SizedBox(height: 8.0),
+                          ],
+                        ),
+                      // 区切り線
+                      Container(
+                        decoration: const BoxDecoration(
+                          border: Border(
+                            bottom: BorderSide(
+                              color: Colors.black,
+                              width: 1,
+                            ),
+                          ),
+                        ),
                       ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Column(
-                  // ignore: prefer_const_literals_to_create_immutables
-                  children: [
-                    const QuizChoices(),
-                    const GoNextButton(),
-                    const AnswerResult(),
-                  ],
+                // 回答 領域
+                Expanded(
+                  flex: 1,
+                  child: Column(
+                    // ignore: prefer_const_literals_to_create_immutables
+                    children: [
+                      const QuizChoices(),
+                      const GoNextButton(),
+                      const AnswerResult(),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         );
       },

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -36,7 +36,7 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
     // ignore: dead_code
     const colorArea = isDebug ? Colors.white : Colors.transparent;
     // ignore: dead_code
-    final colorBackground = isDebug ? Colors.amber[100] : Colors.white;
+    final colorBackground = isDebug ? Colors.grey[100] : Colors.amber[25];
 
     return FutureBuilder(
       future: (!isFirstLoad && popQuestion.imagePath != '')

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -142,7 +142,6 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
                                 const SizedBox(height: 8.0),
                               ],
                             ),
-                          // 区切り線
                         ],
                       ),
                     ),

--- a/lib/view/try_questions/questions_area.dart
+++ b/lib/view/try_questions/questions_area.dart
@@ -3,9 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:past_questions/view/try_questions/try_questions.dart';
 
 import '../../questions/question.dart';
-import 'parts/answer_result.dart';
-import 'parts/go_next_button.dart';
+import 'parts/quiz_answer_result.dart';
 import 'parts/quiz_choices.dart';
+import 'parts/quiz_devider.dart';
+import 'parts/quiz_go_next_button.dart';
+import 'parts/quiz_question_info.dart';
+import 'parts/quiz_question.dart';
 
 class QuestionArea extends ConsumerStatefulWidget {
   const QuestionArea({super.key});
@@ -30,13 +33,12 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
 
     const paddingScreen = 16.0;
     const marginAreaBottom = 8.0;
-
     // for Debug
     const isDebug = false;
     // ignore: dead_code
-    const colorArea = isDebug ? Colors.white : Colors.transparent;
+    const debugColorArea = isDebug ? Colors.white : Colors.transparent;
     // ignore: dead_code
-    final colorBackground = isDebug ? Colors.grey[100] : Colors.amber[25];
+    final debugColorBackground = isDebug ? Colors.grey[100] : Colors.amber[25];
 
     return FutureBuilder(
       future: (!isFirstLoad && popQuestion.imagePath != '')
@@ -53,123 +55,38 @@ class QuestionAreaState extends ConsumerState<QuestionArea> {
         }
         return Scaffold(
           body: Container(
-            color: colorBackground,
+            color: debugColorBackground,
             child: Padding(
               padding: const EdgeInsets.all(paddingScreen),
               child: Column(
-                children: <Widget>[
-                  // 問題情報 領域
-                  Container(
-                    color: colorArea,
-                    child: Row(
-                      children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Container(
-                                margin: const EdgeInsets.all(1.0),
-                                child: const Text('この問題何回目: ...')),
-                            Container(
-                                margin: const EdgeInsets.all(1.0),
-                                child: const Text('全体正解率:100%')),
-                          ],
-                        ),
-                        const Spacer(),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.end,
-                          children: [
-                            Container(
-                              margin: const EdgeInsets.all(1.0),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 5, vertical: 1.0),
-                              decoration: BoxDecoration(
-                                color: Colors.pink[300],
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              child: const Text('アルゴリズムとプログラミング'),
-                            ),
-                            const SizedBox(
-                              height: 1,
-                            ),
-                            Container(
-                              margin: const EdgeInsets.all(1.0),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 5, vertical: 1.0),
-                              decoration: BoxDecoration(
-                                color: Colors.purple[300],
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              child: const Text('テクノロジー'),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                children: [
+                  const ColoredBox(
+                    color: debugColorArea,
+                    child: QuizQuestionInfo(),
                   ),
                   const SizedBox(height: marginAreaBottom),
-                  // 区切り線
-                  Container(
-                    decoration: const BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: Color(0xFF333333),
-                          width: 1,
-                        ),
-                      ),
-                    ),
-                  ),
+                  const QuizDevider(),
                   const SizedBox(height: marginAreaBottom),
-                  // 問題 領域 (最大:画面上部50%)
                   Expanded(
                     flex: 1,
-                    child: Container(
-                      color: colorArea,
+                    child: ColoredBox(
+                      color: debugColorArea,
+                      child: QuizQuestion(popQuestion: popQuestion),
+                    ),
+                  ),
+                  const SizedBox(height: marginAreaBottom),
+                  const QuizDevider(),
+                  const SizedBox(height: marginAreaBottom),
+                  Expanded(
+                    flex: 1,
+                    child: ColoredBox(
+                      color: debugColorArea,
                       child: ListView(
-                        children: [
-                          // 問題 本文
-                          Text(popQuestion.text),
-                          const SizedBox(height: 8.0),
-                          // 問題 付図
-                          if (popQuestion.imagePath != '')
-                            Column(
-                              children: [
-                                Image.asset(
-                                  popQuestion.imagePath,
-                                  width:
-                                      MediaQuery.of(context).size.width * 0.95,
-                                  fit: BoxFit.fitWidth,
-                                ),
-                                const SizedBox(height: 8.0),
-                              ],
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: marginAreaBottom),
-                  // 区切り線
-                  Container(
-                    decoration: const BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: Color(0xFF333333),
-                          width: 1,
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: marginAreaBottom),
-                  // 回答 領域
-                  Expanded(
-                    flex: 1,
-                    child: Container(
-                      color: colorArea,
-                      child: Column(
                         // ignore: prefer_const_literals_to_create_immutables
                         children: [
                           const QuizChoices(),
-                          const GoNextButton(),
-                          const AnswerResult(),
+                          const QuizGoNextButton(),
+                          const QuizAnswerResult(),
                         ],
                       ),
                     ),


### PR DESCRIPTION
◆したこと
1. テーマカラーをオレンジにしました（main.dartのMaterialApp()あたりにDataThemeを設定）
2. 問題回答画面全体をパディングなどで見た目を改善しました
3. 問題回答画面の上部に情報欄スペースを設けました
4. 問題回答画面の下部もListViewでスクロールできるようにしました。
5. 問題回答画面の下部の選択肢見た目を整えました（ボタンはアイウエの丸部分）
6. 上部情報欄、問題欄、区切り線、を別ファイルにしました（choises, go_next, answer_resultが別ファイルだったのに合わせて）
7. view/try_questions/parts/ 内のファイル名を同じようなプレフィックスの名前に変更

◆まだのこと
1. 2x2選択肢欄（まずは実装がシンプルな1x4のみ作業）
2. 問題データの取り込みと反映

よろしくお願いします。
