### PR TITLE
過去問Widgetの配置

### DIFF
--- a/lib/View/try_questions/choose_years.dart
+++ b/lib/View/try_questions/choose_years.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:past_questions/View/try_questions/test_choice/test_choice.dart';
 import 'package:past_questions/questions/question.dart';
 import 'package:past_questions/service/database/study_state_db.dart';
 import 'package:past_questions/service/database/user_records_db.dart';
@@ -86,6 +87,17 @@ class ChooseYearsState extends ConsumerState<ChooseYears> {
               _refreshJournals();
             },
             child: const Text('全記録削除'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => TestChoiceScreen(),
+                ),
+              );
+            },
+            child: const Text('asano'),
           ),
           const Spacer(),
           Row(

--- a/lib/View/try_questions/test_choice/result.dart
+++ b/lib/View/try_questions/test_choice/result.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+
+import 'package:past_questions/View/try_questions/test_choice/result_detail.dart';
+
+enum QuestionPattern {
+  savedata,
+  nomal,
+  correct_per,
+  after_pass,
+  unCorrect_q,
+}
+
+class ResultScreen extends StatefulWidget {
+  const ResultScreen({super.key});
+
+  @override
+  State<ResultScreen> createState() => _ResultScreenState();
+}
+
+class _ResultScreenState extends State<ResultScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text("result"),
+        ),
+        body: Column(
+          children: [
+            Row(
+              children: [
+                ResultSquareFrame(
+                  title: "回答数",
+                  amount: 15,
+                ),
+                ResultSquareFrame(
+                  title: "正解数",
+                  amount: 5,
+                ),
+                ResultSquareFrame(
+                  title: "正解率",
+                  amount: 22,
+                ),
+                ResultSquareFrame(
+                  title: "一覧",
+                ),
+              ],
+            ),
+            const ResultCategoryFrame(
+              height: 20,
+              name: "分野",
+              question_amount: "回答数",
+              correct_amount: "正解数",
+              solo_cor_per: "個人正解",
+              all_cor_per: "全体正解",
+              topic: true,
+            ),
+            //co
+            ResultCategoryFrame(
+              height: 50,
+              name: "ストラテジ",
+              question_amount: 14.toString(),
+              correct_amount: 7.toString(),
+              solo_cor_per: 50.toString(),
+              all_cor_per: 66.toString(),
+              bgColor: Colors.lightBlue.shade100,
+              topic: false,
+            ),
+            Expanded(
+              child: ListView.builder(
+                  itemCount: 5,
+                  itemBuilder: (context, index) {
+                    return Column(
+                      children: [
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        ResultCategoryFrame(
+                          height: 20,
+                          name: "四則",
+                          question_amount: 7.toString(),
+                          correct_amount: 5.toString(),
+                          solo_cor_per: 60.toString(),
+                          all_cor_per: 33.toString(),
+                          topic: false,
+                        ),
+                      ],
+                    );
+                  }),
+            ),
+            //co
+            ResultCategoryFrame(
+              height: 50,
+              name: "マネジメント",
+              question_amount: 14.toString(),
+              correct_amount: 7.toString(),
+              solo_cor_per: 50.toString(),
+              all_cor_per: 66.toString(),
+              bgColor: Colors.lightBlue.shade100,
+              topic: false,
+            ),
+            Expanded(
+              child: ListView.builder(
+                  itemCount: 10,
+                  itemBuilder: (context, index) {
+                    return Column(
+                      children: [
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        ResultCategoryFrame(
+                          height: 20,
+                          name: "四則",
+                          question_amount: 7.toString(),
+                          correct_amount: 5.toString(),
+                          solo_cor_per: 60.toString(),
+                          all_cor_per: 33.toString(),
+                          topic: false,
+                        ),
+                      ],
+                    );
+                  }),
+            ),
+            //co
+            ResultCategoryFrame(
+              height: 50,
+              name: "テクノロジ",
+              question_amount: 14.toString(),
+              correct_amount: 7.toString(),
+              solo_cor_per: 50.toString(),
+              all_cor_per: 66.toString(),
+              bgColor: Colors.lightBlue.shade100,
+              topic: false,
+            ),
+            Expanded(
+              child: ListView.builder(
+                  itemCount: 5,
+                  itemBuilder: (context, index) {
+                    return Column(
+                      children: [
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        ResultCategoryFrame(
+                          height: 20,
+                          name: "四則",
+                          question_amount: 7.toString(),
+                          correct_amount: 5.toString(),
+                          solo_cor_per: 60.toString(),
+                          all_cor_per: 33.toString(),
+                          topic: false,
+                        ),
+                      ],
+                    );
+                  }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ResultSquareFrame extends StatefulWidget {
+  const ResultSquareFrame({required this.title, this.amount, super.key});
+  final String title;
+  final int? amount;
+
+  @override
+  State<ResultSquareFrame> createState() => _ResultSquareFrameState();
+}
+
+class _ResultSquareFrameState extends State<ResultSquareFrame> {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.all(3.0),
+        child: GestureDetector(
+          onTap: () {
+            widget.title == "一覧"
+                ? Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => ResultDetail()),
+                  )
+                : Container();
+          },
+          child: Container(
+            height: 100,
+            color: Colors.amber,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Text(widget.title),
+                widget.amount != null
+                    ? Text(
+                        widget.amount.toString(),
+                        style: TextStyle(fontSize: 30),
+                      )
+                    : Icon(Icons.arrow_right),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    ;
+  }
+}
+
+class ResultCategoryFrame extends StatefulWidget {
+  const ResultCategoryFrame(
+      {required this.height,
+      required this.name,
+      required this.question_amount,
+      required this.correct_amount,
+      required this.solo_cor_per,
+      required this.all_cor_per,
+      this.bgColor,
+      required this.topic,
+      super.key});
+
+  final double height;
+  final String name;
+  final String question_amount;
+  final String correct_amount;
+  final String solo_cor_per;
+  final String all_cor_per;
+  final Color? bgColor;
+  final bool topic;
+
+  @override
+  State<ResultCategoryFrame> createState() => _ResultCategoryFrameState();
+}
+
+class _ResultCategoryFrameState extends State<ResultCategoryFrame> {
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle basefont =
+        TextStyle().copyWith(fontSize: 20, fontWeight: FontWeight.bold);
+    return Container(
+      height: widget.height,
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20), color: widget.bgColor),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 2,
+            child: Center(
+              child: Text(widget.name),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: Text(widget.question_amount.toString()),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: Text(widget.correct_amount),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: RichText(
+                text: TextSpan(
+                  text: widget.solo_cor_per,
+                  style: DefaultTextStyle.of(context).style,
+                  children: <TextSpan>[
+                    widget.topic
+                        ? const TextSpan(
+                            text: '',
+                          )
+                        : const TextSpan(
+                            text: '%',
+                            style: TextStyle(fontSize: 10),
+                          )
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: RichText(
+                text: TextSpan(
+                  text: widget.all_cor_per,
+                  style: DefaultTextStyle.of(context).style,
+                  children: <TextSpan>[
+                    widget.topic
+                        ? TextSpan(
+                            text: '',
+                          )
+                        : TextSpan(
+                            text: '%',
+                            style: TextStyle(fontSize: 10),
+                          )
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/View/try_questions/test_choice/result_detail.dart
+++ b/lib/View/try_questions/test_choice/result_detail.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/container.dart';
+import 'package:flutter/src/widgets/framework.dart';
+
+class ResultDetail extends StatefulWidget {
+  const ResultDetail({super.key});
+
+  @override
+  State<ResultDetail> createState() => _ResultDetailState();
+}
+
+class _ResultDetailState extends State<ResultDetail> {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('詳細'),
+        ),
+        body: Column(
+          children: [
+            QuestionDetailFrame(
+              all_per: '全体%',
+              answer: '解答',
+              category: 'カテゴリ',
+              q_No: 'No.',
+              title: '問題概要',
+              bgColor: Colors.orange.shade600,
+            ),
+            Expanded(
+              child: ListView.builder(
+                  itemCount: 25,
+                  itemBuilder: (context, index) {
+                    return QuestionDetailFrame(
+                      all_per: '56',
+                      answer: '〇',
+                      category: 'テクノロジ',
+                      q_No: '001',
+                      title: 'HDDに関する問題',
+                      bgColor: Colors.orange.shade100,
+                    );
+                  }),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class QuestionDetailFrame extends StatefulWidget {
+  const QuestionDetailFrame(
+      {required this.answer,
+      required this.q_No,
+      required this.category,
+      required this.title,
+      required this.all_per,
+      required this.bgColor,
+      super.key});
+
+  final String answer;
+  final String q_No;
+  final String category;
+  final String title;
+  final String all_per;
+  final Color bgColor;
+
+  @override
+  State<QuestionDetailFrame> createState() => _QuestionDetailFrameState();
+}
+
+class _QuestionDetailFrameState extends State<QuestionDetailFrame> {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(1.0),
+      child: Container(
+        height: 40,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          color: widget.bgColor,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Container(
+                child: Center(
+                  child: Text(widget.answer),
+                ),
+              ),
+            ),
+            Expanded(child: Center(child: Text("Q${widget.q_No}"))),
+            Expanded(
+              flex: 3,
+              child: Chip(
+                label: Text(
+                  widget.category,
+                  style: TextStyle(fontSize: 8),
+                ),
+                elevation: 1,
+              ),
+            ),
+            Expanded(
+              flex: 5,
+              child: Center(
+                child: Text(
+                  widget.title,
+                  style: TextStyle(wordSpacing: 4),
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Center(
+                child: RichText(
+                  text: TextSpan(
+                    text: widget.all_per,
+                    style: DefaultTextStyle.of(context).style,
+                    children: <TextSpan>[
+                      // widget.topic
+                      //     ? const TextSpan(
+                      //         text: '',
+                      //       )
+                      //     :
+                      const TextSpan(
+                        text: '%',
+                        style: TextStyle(fontSize: 10),
+                      )
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/View/try_questions/test_choice/test_choice.dart
+++ b/lib/View/try_questions/test_choice/test_choice.dart
@@ -1,0 +1,337 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/container.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:past_questions/View/try_questions/test_choice/result.dart';
+
+class TestChoiceScreen extends StatefulWidget {
+  const TestChoiceScreen({super.key});
+
+  @override
+  State<TestChoiceScreen> createState() => _TestChoiceScreenState();
+}
+
+class _TestChoiceScreenState extends State<TestChoiceScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  static const List<Tab> myTabs = <Tab>[
+    Tab(text: '中断'),
+    Tab(text: '通常'),
+    Tab(text: '回答率'),
+    Tab(text: '後で見る'),
+    Tab(text: 'PASS'),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(vsync: this, length: myTabs.length);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("過去問を解く"),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                //
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    TitleFrame('年度'),
+                    AllChoinceFrame(),
+                  ],
+                ),
+                YearQuestionFrame(height: 20),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: 20,
+                    itemBuilder: (context, index) {
+                      return Padding(
+                        padding: const EdgeInsets.all(1.0),
+                        child: YearQuestionFrame(height: 30),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          //
+          Divider(height: 5),
+          Expanded(
+            child: Column(
+              children: [
+                //
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    TitleFrame('カテゴリ'),
+                    AllChoinceFrame(),
+                  ],
+                ),
+                YearQuestionFrame(height: 20),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: 20,
+                    itemBuilder: (context, index) {
+                      return Padding(
+                        padding: const EdgeInsets.all(1.0),
+                        child: YearQuestionFrame(height: 30),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          //
+          Expanded(
+            child: DefaultTabController(
+              length: myTabs.length,
+              child: Container(
+                color: Colors.amber,
+                child: Column(
+                  children: [
+                    SizedBox(
+                      height: 25,
+                      child: TabBar(
+                        isScrollable: true,
+                        indicatorSize: TabBarIndicatorSize.label,
+                        // indicatorWeight: 20,
+
+                        indicator: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          color: Colors.greenAccent,
+                        ),
+                        labelColor: Colors.blue,
+                        unselectedLabelColor: Colors.black,
+                        controller: _tabController,
+                        tabs: myTabs,
+                      ),
+                    ),
+                    Expanded(
+                      flex: 3,
+                      child: TabBarView(
+                        controller: _tabController,
+                        children: [
+                          BottomScreenFrame(
+                            questionPattern: QuestionPattern.savedata,
+                          ),
+                          BottomScreenFrame(
+                            questionPattern: QuestionPattern.nomal,
+                          ),
+                          BottomScreenFrame(
+                            questionPattern: QuestionPattern.correct_per,
+                          ),
+                          BottomScreenFrame(
+                            questionPattern: QuestionPattern.after_pass,
+                          ),
+                          BottomScreenFrame(
+                            questionPattern: QuestionPattern.unCorrect_q,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class YearQuestionFrame extends StatefulWidget {
+  const YearQuestionFrame({required this.height, super.key});
+  final double height;
+
+  @override
+  State<YearQuestionFrame> createState() => _YearQuestionFrameState();
+}
+
+class _YearQuestionFrameState extends State<YearQuestionFrame> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: widget.height,
+      decoration: BoxDecoration(
+        color: Colors.lightBlue.shade100,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          SizedBox(width: 10),
+          Expanded(flex: 3, child: Text("2019")),
+          Expanded(flex: 1, child: Text("4")),
+          Expanded(flex: 1, child: Text("1")),
+          Expanded(
+            flex: 1,
+            child: RichText(
+              text: TextSpan(
+                text: '15 ',
+                style: DefaultTextStyle.of(context).style,
+                children: const <TextSpan>[
+                  TextSpan(text: '%', style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: RichText(
+              text: TextSpan(
+                text: '15 ',
+                style: DefaultTextStyle.of(context).style,
+                children: const <TextSpan>[
+                  TextSpan(text: '%', style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Widget TitleFrame(String name) {
+  return Container(
+    width: 150,
+    decoration: BoxDecoration(
+      color: Colors.black,
+      borderRadius: BorderRadius.circular(20),
+    ),
+    child: Center(
+      child: Text(
+        name,
+        style: TextStyle(color: Colors.white, fontSize: 15),
+      ),
+    ),
+  );
+}
+
+Widget AllChoinceFrame() {
+  return Container(
+    width: 150,
+    decoration: BoxDecoration(
+      color: Colors.black,
+      borderRadius: BorderRadius.circular(20),
+    ),
+    child: Center(
+      child: Text(
+        "すべて選択",
+        style: TextStyle(color: Colors.white, fontSize: 15),
+      ),
+    ),
+  );
+}
+
+class BottomScreenFrame extends StatefulWidget {
+  const BottomScreenFrame({required this.questionPattern, super.key});
+
+  final QuestionPattern questionPattern;
+
+  @override
+  State<BottomScreenFrame> createState() => _BottomScreenFrameState();
+}
+
+class _BottomScreenFrameState extends State<BottomScreenFrame> {
+  final TextEditingController qustion_amount = TextEditingController();
+  RangeValues _currentRangeValues = const RangeValues(0, 80);
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        (widget.questionPattern == QuestionPattern.savedata)
+            ? ElevatedButton(
+                onPressed: () {},
+                child: Text("前回のデータの続きから"),
+              )
+            : Container(),
+        (widget.questionPattern == QuestionPattern.correct_per)
+            ? Column(
+                children: [
+                  Text(
+                      "${_currentRangeValues.start.toStringAsFixed(0)}% - ${_currentRangeValues.end.toStringAsFixed(0)}%"),
+                  RangeSlider(
+                    max: 100.0,
+                    divisions: 20,
+                    labels: RangeLabels(
+                      _currentRangeValues.start.round().toString(),
+                      _currentRangeValues.end.round().toString(),
+                    ),
+                    values: _currentRangeValues,
+                    onChanged: (RangeValues values) {
+                      setState(() {
+                        _currentRangeValues = values;
+                      });
+                    },
+                  ),
+                ],
+              )
+            : Container(),
+        (widget.questionPattern != QuestionPattern.savedata)
+            ? Row(
+                children: [
+                  Expanded(
+                    child: Container(
+                      height: 40,
+                      child: ElevatedButton(
+                        child: Text("選択した問題をすべて解く"),
+                        onPressed: () {},
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 5),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {},
+                      child: Container(
+                        color: Colors.blue,
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Container(
+                                color: Colors.white,
+                                child: TextFormField(
+                                  controller: qustion_amount,
+                                  keyboardType: TextInputType.number,
+                                ),
+                              ),
+                            ),
+                            Text('/??問をランダムで解く'),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            : Container(),
+        ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => ResultScreen()),
+              );
+            },
+            child: Text("解答を開始する"))
+      ],
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 import sqflite
 import sqlite3_flutter_libs
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   async:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.2"
+    version: "8.4.3"
   characters:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   cli_util:
     dependency: transitive
     description:
@@ -182,14 +182,14 @@ packages:
       name: drift
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.2"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.1"
   fake_async:
     dependency: transitive
     description:
@@ -236,7 +236,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -267,7 +267,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.3"
   graphs:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   lints:
     dependency: transitive
     description:
@@ -323,7 +323,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   package_config:
     dependency: transitive
     description:
@@ -372,7 +372,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   path_provider_android:
     dependency: transitive
     description:
@@ -380,13 +380,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.22"
-  path_provider_ios:
+  path_provider_foundation:
     dependency: transitive
     description:
-      name: path_provider_ios
+      name: path_provider_foundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.1.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -394,13 +394,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -470,7 +463,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
@@ -496,7 +489,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.6"
+    version: "1.2.7"
   source_span:
     dependency: transitive
     description:
@@ -510,14 +503,14 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.4+1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0+2"
+    version: "2.4.2+2"
   sqlite3:
     dependency: transitive
     description:
@@ -538,7 +531,7 @@ packages:
       name: sqlparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.24.0"
+    version: "0.26.1"
   stack_trace:
     dependency: transitive
     description:
@@ -580,7 +573,7 @@ packages:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0+3"
+    version: "3.0.1"
   term_glyph:
     dependency: transitive
     description:
@@ -601,7 +594,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -629,7 +622,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   win32:
     dependency: transitive
     description:
@@ -643,7 +636,7 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "0.2.0+3"
   yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
過去問の関する部分
・問題を選択する画面
・リザルト画面
・リザルト詳細画面
を簡単に作成しました。
（問題を解く画面はmanoさんが作成しています）

PastQuiz\lib\View\try_questions\test_choice内にあります。

ビルドで確認する際は、初期画面の縦に5つボタンがある下に仮で作成しましたのでそこから見てください

![image](https://user-images.githubusercontent.com/36097062/216819308-a7f17f9f-eede-4548-839f-46d65560f619.png)




